### PR TITLE
Do not open a (migration-)file if escape key was pressed

### DIFF
--- a/SublimeRailsMigrationsList.py
+++ b/SublimeRailsMigrationsList.py
@@ -32,6 +32,7 @@ class RailsMigrationsListCommand(sublime_plugin.WindowCommand):
 
 
   def get_file(self, index):
+    if index >= 0:
       url = os.path.join(self.migrations_dir, self.fileList[index])
       self.window.open_file(url)
 


### PR DESCRIPTION
I've "stolen" this from [SublimeText2RailsRelatedFiles](https://github.com/luqman/SublimeText2RailsRelatedFiles/blob/master/Rails.py#L228) as it was sort of annoying.

Be aware that it worked for me but I absolutely have no clue about python in general. I was a bit confused though as everything was indented with 2 spaces except the method I'd edited.
