### PR TITLE
Fall back to project folder when no file is open

### DIFF
--- a/SublimeRailsMigrationsList.py
+++ b/SublimeRailsMigrationsList.py
@@ -7,11 +7,14 @@ class RailsMigrationsListCommand(sublime_plugin.WindowCommand):
   migrations = []
   migrations_dir = ''
   def run(self):
+    cur_path = None
     try:
       cur_path = self.window.active_view().file_name()
     except AttributeError:
-      if self.window.folders():
-        cur_path = self.window.folders()[0]
+      pass
+
+    if not cur_path and self.window.folders():
+      cur_path = self.window.folders()[0]
 
     if cur_path:
       if os.path.isfile(cur_path):


### PR DESCRIPTION
The folder fallback was inside the AttributeError handler, so it only triggered when there was no active view at all. When a view existed but had no file (e.g. untitled tab), file_name() returned None instead of raising, skipping the fallback entirely.

Fixes #3 